### PR TITLE
fix: impl error for Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ readme = "README.md"
 keywords = ["ids", "encode", "short", "sqids", "hashids"]
 
 [dependencies]
-derive_more = "0.99.17"
 serde = "1.0.188"
 serde_json = "1.0.107"
+thiserror = "1.0.49"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,18 @@
-use derive_more::Display;
 use std::{cmp::min, collections::HashSet, result};
 
-#[derive(Display, Debug, Eq, PartialEq)]
+use thiserror::Error;
+
+#[derive(Error, Debug, Eq, PartialEq)]
 pub enum Error {
-	#[display(fmt = "Alphabet cannot contain multibyte characters")]
+	#[error("Alphabet cannot contain multibyte characters")]
 	AlphabetMultibyteCharacters,
-	#[display(fmt = "Alphabet length must be at least 3")]
+	#[error("Alphabet length must be at least 3")]
 	AlphabetLength,
-	#[display(fmt = "Alphabet must contain unique characters")]
+	#[error("Alphabet must contain unique characters")]
 	AlphabetUniqueCharacters,
-	#[display(fmt = "Reached max attempts to re-generate the ID")]
+	#[error("Reached max attempts to re-generate the ID")]
 	BlocklistMaxAttempts,
 }
-
-impl std::error::Error for Error {}
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub enum Error {
 	BlocklistMaxAttempts,
 }
 
+impl std::error::Error for Error {}
+
 pub type Result<T> = result::Result<T, Error>;
 
 pub fn default_blocklist() -> HashSet<String> {


### PR DESCRIPTION
~~The error type did not implement std::error::Error, this just adds that line.~~
I just used thiserror instead since that is probably more idiomatic and the derive more wasn't used anywhere else.