### PR TITLE
Ergonomics and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["ids", "encode", "short", "sqids", "hashids"]
 
 [dependencies]
+derive_builder = "0.12.0"
 serde = "1.0.192"
 serde_json = "1.0.108"
 thiserror = "1.0.50"

--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ let numbers = sqids.decode(&id); // [1, 2, 3]
 Enforce a *minimum* length for IDs:
 
 ```rust
-let sqids = Sqids::new(Some(Options::new(
-  None,
-  Some(10),
-  None,
-)))?;
+let sqids = Sqids::builder()
+  .min_length(10)
+  .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "86Rf07xd4z"
 let numbers = sqids.decode(&id); // [1, 2, 3]
 ```
@@ -66,11 +64,9 @@ let numbers = sqids.decode(&id); // [1, 2, 3]
 Randomize IDs by providing a custom alphabet:
 
 ```rust
-let sqids = Sqids::new(Some(Options::new(
-  Some("FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE".to_string()),
-  None,
-  None,
-)))?;
+let sqids = Sqids::builder()
+  .alphabet("FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE".chars().collect())
+  .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "B4aajs"
 let numbers = sqids.decode(&id); // [1, 2, 3]
 ```
@@ -78,11 +74,9 @@ let numbers = sqids.decode(&id); // [1, 2, 3]
 Prevent specific words from appearing anywhere in the auto-generated IDs:
 
 ```rust
-let sqids = Sqids::new(Some(Options::new(
-  None,
-  None,
-  Some(HashSet::from(["86Rf07".to_string()])),
-)))?;
+let sqids = Sqids::builder()
+  .blocklist(HashSet::from(["86Rf07".to_string()]))
+  .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "se8ojk"
 let numbers = sqids.decode(&id); // [1, 2, 3]
 ```

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ cargo add sqids
 Simple encode & decode:
 
 ```rust
+# use sqids::Sqids;
 let sqids = Sqids::default();
 let id = sqids.encode(&[1, 2, 3])?; // "86Rf07"
 let numbers = sqids.decode(&id); // [1, 2, 3]
+# Ok::<(), sqids::Error>(())
 ```
 
 > **Note**
@@ -54,31 +56,37 @@ let numbers = sqids.decode(&id); // [1, 2, 3]
 Enforce a *minimum* length for IDs:
 
 ```rust
+# use sqids::Sqids;
 let sqids = Sqids::builder()
   .min_length(10)
   .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "86Rf07xd4z"
 let numbers = sqids.decode(&id); // [1, 2, 3]
+# Ok::<(), sqids::Error>(())
 ```
 
 Randomize IDs by providing a custom alphabet:
 
 ```rust
+# use sqids::Sqids;
 let sqids = Sqids::builder()
   .alphabet("FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE".chars().collect())
   .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "B4aajs"
 let numbers = sqids.decode(&id); // [1, 2, 3]
+# Ok::<(), sqids::Error>(())
 ```
 
 Prevent specific words from appearing anywhere in the auto-generated IDs:
 
 ```rust
+# use sqids::Sqids;
 let sqids = Sqids::builder()
-  .blocklist(HashSet::from(["86Rf07".to_string()]))
+  .blocklist(["86Rf07".to_string()].into())
   .build()?;
 let id = sqids.encode(&[1, 2, 3])?; // "se8ojk"
 let numbers = sqids.decode(&id); // [1, 2, 3]
+# Ok::<(), sqids::Error>(())
 ```
 
 ## 📝 License

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -11,3 +11,4 @@ trailing_comma = "Vertical"
 trailing_semicolon = true
 use_field_init_shorthand = true
 format_macro_bodies = true
+format_code_in_doc_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+#![doc = include_str!("../README.md")]
+
+// Make the link to the LICENSE in README.md work.
+#[cfg(doc)]
+#[doc = include_str!("../LICENSE")]
+///
+/// ---
+/// **Note**: This is the crate's license and not an actual item.
+pub const LICENSE: () = ();
+
 use std::{cmp::min, collections::HashSet, result};
 
 use derive_builder::Builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(missing_docs)]
 #![allow(clippy::tabs_in_doc_comments)]
-
 #![doc = include_str!("../README.md")]
 
 // Make the link to the LICENSE in README.md work.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(missing_docs)]
+#![allow(clippy::tabs_in_doc_comments)]
+
 #![doc = include_str!("../README.md")]
 
 // Make the link to the LICENSE in README.md work.
@@ -13,34 +16,78 @@ use std::{cmp::min, collections::HashSet, result};
 use derive_builder::Builder;
 use thiserror::Error;
 
+/// sqids Error type.
 #[derive(Error, Debug, Eq, PartialEq)]
 pub enum Error {
+	/// Alphabet cannot contain multibyte characters
+	///
+	/// ```
+	/// # use sqids::{Sqids, Error};
+	/// let error = Sqids::builder().alphabet("☃️🦀🔥".chars().collect()).build().unwrap_err();
+	/// assert_eq!(error, Error::AlphabetMultibyteCharacters);
+	/// ```
 	#[error("Alphabet cannot contain multibyte characters")]
 	AlphabetMultibyteCharacters,
+	/// Alphabet length must be at least 3
+	///
+	/// ```
+	/// # use sqids::{Sqids, Error};
+	/// let error = Sqids::builder().alphabet("ab".chars().collect()).build().unwrap_err();
+	/// assert_eq!(error, Error::AlphabetLength);
+	/// ```
 	#[error("Alphabet length must be at least 3")]
 	AlphabetLength,
+	/// Alphabet must contain unique characters
+	///
+	/// ```
+	/// # use sqids::{Sqids, Error};
+	/// let error = Sqids::builder().alphabet("aba".chars().collect()).build().unwrap_err();
+	/// assert_eq!(error, Error::AlphabetUniqueCharacters);
+	/// ```
 	#[error("Alphabet must contain unique characters")]
 	AlphabetUniqueCharacters,
+	/// Reached max attempts to re-generate the ID
+	///
+	/// ```
+	/// # use sqids::{Sqids, Error};
+	/// let sqids = Sqids::builder()
+	/// 	.alphabet("abc".chars().collect())
+	/// 	.min_length(3)
+	/// 	.blocklist(["aac".to_string(), "bba".to_string(), "ccb".to_string()].into())
+	/// 	.build()
+	/// 	.unwrap();
+	/// let error = sqids.encode(&[1]).unwrap_err();
+	/// assert_eq!(error, Error::BlocklistMaxAttempts);
+	/// ```
 	#[error("Reached max attempts to re-generate the ID")]
 	BlocklistMaxAttempts,
 }
 
+/// type alias for Result<T, Error>
 pub type Result<T> = result::Result<T, Error>;
 
+/// The default alphabet used when none is given when creating a [Sqids].
 pub const DEFAULT_ALPHABET: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
+/// Returns the default blocklist when none is given when creating a [Sqids].
 pub fn default_blocklist() -> HashSet<String> {
 	serde_json::from_str(include_str!("blocklist.json")).unwrap()
 }
 
+/// Options for creating a [Sqids].
 #[derive(Debug)]
 pub struct Options {
+	/// The [Sqids] alphabet.
 	pub alphabet: String,
+	/// The minimum length of a sqid.
 	pub min_length: u8,
+	/// Blocklist. When creating a sqid [Sqids] will try to avoid generating a string that begins
+	/// with one of these.
 	pub blocklist: HashSet<String>,
 }
 
 impl Options {
+	/// Create an [Options] object.
 	pub fn new(
 		alphabet: Option<String>,
 		min_length: Option<u8>,
@@ -72,11 +119,16 @@ impl Default for Options {
 	}
 }
 
+/// A generator for sqids.
 #[derive(Debug, Builder)]
 #[builder(build_fn(skip, error = "Error"), pattern = "owned")]
 pub struct Sqids {
+	/// The alphabet that is being used when generating sqids.
 	alphabet: Vec<char>,
+	/// The minimum length of a sqid.
 	min_length: u8,
+	/// Blocklist. When creating a sqid strings that begins
+	/// with one of these will be avoided.
 	blocklist: HashSet<String>,
 }
 
@@ -87,10 +139,12 @@ impl Default for Sqids {
 }
 
 impl SqidsBuilder {
+	/// Create a [SqidsBuilder].
 	pub fn new() -> Self {
 		Self::default()
 	}
 
+	/// Build a [Sqids] object.
 	pub fn build(self) -> Result<Sqids> {
 		let alphabet: Vec<char> =
 			self.alphabet.unwrap_or_else(|| DEFAULT_ALPHABET.chars().collect());
@@ -135,6 +189,7 @@ impl SqidsBuilder {
 }
 
 impl Sqids {
+	/// Create a [Sqids] from [Options].
 	pub fn new(options: Option<Options>) -> Result<Self> {
 		let options = options.unwrap_or_default();
 		Self::builder()
@@ -144,10 +199,17 @@ impl Sqids {
 			.build()
 	}
 
+	/// Create a [SqidsBuilder].
 	pub fn builder() -> SqidsBuilder {
 		SqidsBuilder::default()
 	}
 
+	/// Generate a sqid from a slice of numbers.
+	///
+	/// When an sqid is generated it is checked against the [SqidsBuilder::blocklist]. When a
+	/// blocked word is encountered another attempt is made by shifting the alphabet.
+	/// When the alphabet is exhausted and all possible sqids for this input are blocked
+	/// [Error::BlocklistMaxAttempts] is returned.
 	pub fn encode(&self, numbers: &[u64]) -> Result<String> {
 		if numbers.is_empty() {
 			return Ok(String::new());
@@ -156,6 +218,8 @@ impl Sqids {
 		self.encode_numbers(numbers, 0)
 	}
 
+	/// Decode a sqid into a vector of numbers. When an invalid sqid is encountered an empty vector
+	/// is returned.
 	pub fn decode(&self, id: &str) -> Vec<u64> {
 		let mut ret = Vec::new();
 

--- a/tests/blocklist.rs
+++ b/tests/blocklist.rs
@@ -39,11 +39,13 @@ fn blocklist() {
 		None,
 		None,
 		Some(HashSet::from([
-			"JSwXFaosAN".to_owned(), // normal result of 1st encoding, let's block that word on purpose
+			"JSwXFaosAN".to_owned(), /* normal result of 1st encoding, let's block that word on
+			                          * purpose */
 			"OCjV9JK64o".to_owned(), // result of 2nd encoding
-			"rBHf".to_owned(),       // result of 3rd encoding is `4rBHfOiqd3`, let's block a substring
-			"79SM".to_owned(),       // result of 4th encoding is `dyhgw479SM`, let's block the postfix
-			"7tE6".to_owned(),       // result of 4th encoding is `7tE6jdAHLe`, let's block the prefix
+			"rBHf".to_owned(),       /* result of 3rd encoding is `4rBHfOiqd3`, let's block a
+			                          * substring */
+			"79SM".to_owned(), // result of 4th encoding is `dyhgw479SM`, let's block the postfix
+			"7tE6".to_owned(), // result of 4th encoding is `7tE6jdAHLe`, let's block the prefix
 		])),
 	)))
 	.unwrap();
@@ -87,7 +89,8 @@ fn blocklist_filtering_in_constructor() {
 	let sqids = Sqids::new(Some(Options::new(
 		Some("ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string()),
 		None,
-		Some(HashSet::from(["sxnzkl".to_owned()])), // lowercase blocklist in only-uppercase alphabet
+		Some(HashSet::from(["sxnzkl".to_owned()])), /* lowercase blocklist in only-uppercase
+		                                             * alphabet */
 	)))
 	.unwrap();
 


### PR DESCRIPTION
This PR tries to attempt a couple of issues at once:

* Add a `SquidBuilder` struct as an alternative to `Options`. I believe this
  makes the code more readable. For example instead of
  ```
  let sqids = Sqids::new(Some(Options::new(
    None,
    Some(10),
    None,
  )))?;
  ```
  We can now write:
  ```
  let sqids = Sqids::builder()
    .min_length(10)
    .build()?;
  ```
  If this is accepted I suggest deprecating `Options` in favor of
  `SqidsBuilder` and removing it in the `1.0` release.
* Pull in the `README.md` file as a crate-level doc-comment. This makes the
  docs much more approachable since now the main doc page has actual useful
  information instead of being a barren waste land. Since the `README.md`
  links to the `LICENSE` file I used a small hack to ensure that this link is
  still valid.
* Pulling in the `README.md` file automatically turned the code examples into
  documentation tests. These were immediately broken because of missing imports
  and error handling. I've added the necessary boilerplate. It's hidden by
  `rustdoc` but unfortunately looks a bit ugly when viewing the `README.md` on
  Github.
* Add basic doc comments to every public item and warn when new items are added
  without docs. If I were maintainer of this crate, I'd turn this into a
  `deny`.

Let me know if you want me to pull this apart into multiple PRs instead.