### PR TITLE
Derive `Clone` trait for `Sqids` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl Default for Options {
 }
 
 /// A generator for sqids.
-#[derive(Debug, Builder)]
+#[derive(Clone, Debug, Builder)]
 #[builder(build_fn(skip, error = "Error"), pattern = "owned")]
 pub struct Sqids {
 	/// The alphabet that is being used when generating sqids.


### PR DESCRIPTION
## Add `Clone` trait to `Sqids` struct

This pull request introduces the `Clone` trait to the `Sqids` struct, allowing for copying of squid generators. 

**Changes:**

* The `#[derive(Clone, Debug, Builder)]` attribute is added to the `Sqids` struct definition, enabling the automatic implementation of the `Clone` trait alongside the existing `Debug` and `Builder` traits.

**Benefits:**

* **Simplified usage:** Code using `Sqids` can now easily create independent copies.